### PR TITLE
Adapt logerrors for pg19 ABI change in ShmemInitHash()

### DIFF
--- a/logerrors.c
+++ b/logerrors.c
@@ -431,7 +431,11 @@ logerrors_shmem_startup(void) {
     ctl.keysize = sizeof(ErrorCode);
     ctl.entrysize = sizeof(ErrorName);
     error_names_hashtable = ShmemInitHash("logerrors hash",
+#if PG_VERSION_NUM < 190000
                                             error_codes_count, error_codes_count,
+#else
+					    error_codes_count,
+#endif
                                             &ctl,
 #if PG_VERSION_NUM < 100000
                                             HASH_ELEM);


### PR DESCRIPTION
init & max size args are merged circa [9ebe1c4f2c7c](http://github.com/postgres/postgres/commit/9ebe1c4f2c7c)